### PR TITLE
Change semantics of `define`, `call` and `call-direct`

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,19 +31,15 @@ https://www.stackage.org/package/rio
 コンパイラでは、ユニークな識別子が欲しくなることがある。
 `Koriel.MonadUniq.getUniq`は、呼ばれるたびにユニークな`Int`を返す。
 
-### Interface
-
 ### Driver
 
 malgoコンパイラのエントリーポイントは`Malgo.Driver.compile`である。
 
-### Pass
-### Rename
-### TypeCheck
-### UTerm
-### Refine
-### Desugar
-### Optimize
-### Flat
-### Alpha
-### CodeGen
+### Koriel
+
+#### Semantics of `call` and `call-direct`
+
+Korielの関数定義は、クロージャを生成する。
+クロージャの呼び出しには`call`を使う。
+呼び出す関数名が明らかでかつ、キャプチャが空のときに限り、`call-direct`で内部の関数を直接呼び出すことができる。
+

--- a/src/Malgo/Desugar/Pass.hs
+++ b/src/Malgo/Desugar/Pass.hs
@@ -200,22 +200,22 @@ dsExpr (G.Var (Typed typ _) name) = do
     -- 引数のない値コンストラクタは、0引数関数の呼び出しに変換する（クロージャは作らない）
     [] :-> _ | isConstructor name -> pure $ CallDirect name' []
     _
-      | idIsExternal name' -> do
-          -- name（name'）がトップレベルで定義されているとき、name'に対応する適切な値（クロージャ）は存在しない。
-          -- そこで、name'の値が必要になったときに、都度クロージャを生成する。
-          case C.typeOf name' of
-            pts :-> _ -> do
-              DsState {globalClosures} <- get
-              case HashMap.lookup name' globalClosures of
-                Nothing -> do
-                  clsId <- newTemporalId ("gblcls_" <> name'.name) (C.typeOf name')
-                  internalFunId <- newTemporalId ("fun_" <> name'.name) (C.typeOf name')
-                  ps <- traverse (newTemporalId "p") pts
-                  let clsDef = VarDef clsId (C.typeOf clsId) $ C.Let [LocalDef internalFunId (C.typeOf internalFunId) (Fun ps $ CallDirect name' $ map C.Var ps)] $ Atom $ C.Var internalFunId
-                  modify $ \s -> s {_globalDefs = clsDef : s._globalDefs, globalClosures = HashMap.insert name' clsId globalClosures}
-                  pure $ Atom $ C.Var clsId
-                Just clsId -> pure $ Atom $ C.Var clsId
-            _ -> pure $ Atom $ C.Var name'
+      -- \| idIsExternal name' -> do
+      --     -- name（name'）がトップレベルで定義されているとき、name'に対応する適切な値（クロージャ）は存在しない。
+      --     -- そこで、name'の値が必要になったときに、都度クロージャを生成する。
+      --     case C.typeOf name' of
+      --       pts :-> _ -> do
+      --         DsState {globalClosures} <- get
+      --         case HashMap.lookup name' globalClosures of
+      --           Nothing -> do
+      --             clsId <- newTemporalId ("gblcls_" <> name'.name) (C.typeOf name')
+      --             internalFunId <- newTemporalId ("fun_" <> name'.name) (C.typeOf name')
+      --             ps <- traverse (newTemporalId "p") pts
+      --             let clsDef = VarDef clsId (C.typeOf clsId) $ C.Let [LocalDef internalFunId (C.typeOf internalFunId) (Fun ps $ CallDirect name' $ map C.Var ps)] $ Atom $ C.Var internalFunId
+      --             modify $ \s -> s {_globalDefs = clsDef : s._globalDefs, globalClosures = HashMap.insert name' clsId globalClosures}
+      --             pure $ Atom $ C.Var clsId
+      --           Just clsId -> pure $ Atom $ C.Var clsId
+      --       _ -> pure $ Atom $ C.Var name'
       | otherwise -> pure $ Atom $ C.Var name'
   where
     isConstructor Id {name} | T.length name > 0 = Char.isUpper (T.head name)

--- a/src/Malgo/Desugar/Pass.hs
+++ b/src/Malgo/Desugar/Pass.hs
@@ -119,7 +119,7 @@ fnToObj isToplevel hint cs@(Clause _ ps e :| _) = do
 
 patToName :: Pat (Malgo 'Refine) -> Text
 patToName (G.VarP _ v) = v.name
-patToName (G.ConP _ c _) = T.toLower $ c.name
+patToName (G.ConP _ c _) = T.toLower c.name
 patToName (G.TupleP _ _) = "tuple"
 patToName (G.RecordP _ _) = "record"
 patToName (G.UnboxedP _ _) = "unboxed"
@@ -265,7 +265,7 @@ dsStmts (G.Let _ v e :| s : ss) = do
 
 -- Desugar Monad
 
-lookupName :: MonadState DsState m => RnId -> m (Id C.Type)
+lookupName :: (MonadState DsState m) => RnId -> m (Id C.Type)
 lookupName name = do
   mname' <- use (nameEnv . at name)
   case mname' of


### PR DESCRIPTION
`define` now introduces a function with a capture parameter. `call-direct` passes NULL as capture to the callee function.