### PR TITLE
Refactor Id

### DIFF
--- a/src/Koriel/Core/Annotate.hs
+++ b/src/Koriel/Core/Annotate.hs
@@ -31,16 +31,16 @@ parseId :: (MonadReader Context m, MonadFail m) => Text -> Type -> m (Id Type)
 parseId name meta
   | Text.head name == '@' = do
       [moduleName, name] <- pure $ Text.words (Text.tail name)
-      pure Id {name, meta, moduleName = ModuleName moduleName, sort = External}
+      pure Id {name, meta, moduleName = ModuleName moduleName, uniq = -1, sort = External}
   | Text.head name == '#' = do
-      [moduleName, name] <- pure $ Text.words (Text.tail name)
-      pure Id {name = Text.tail name, meta, moduleName = ModuleName moduleName, sort = Internal}
+      [moduleName, name, uniq] <- pure $ Text.words (Text.tail name)
+      pure Id {name = Text.tail name, meta, moduleName = ModuleName moduleName, uniq = read $ convertString uniq, sort = Internal}
   | Text.head name == '$' = do
-      [moduleName, name] <- pure $ Text.words (Text.tail name)
-      pure Id {name = Text.tail name, meta, moduleName = ModuleName moduleName, sort = Temporal}
+      [moduleName, name, uniq] <- pure $ Text.words (Text.tail name)
+      pure Id {name = Text.tail name, meta, moduleName = ModuleName moduleName, uniq = read $ convertString uniq, sort = Temporal}
   | Text.head name == '%' = do
       moduleName <- asks (.moduleName)
-      pure Id {name = Text.tail name, meta, moduleName, sort = Native}
+      pure Id {name = Text.tail name, meta, moduleName, uniq = -1, sort = Native}
   | otherwise = do
       error $ "parseId: " <> show name
 

--- a/src/Koriel/Core/Flat.hs
+++ b/src/Koriel/Core/Flat.hs
@@ -26,8 +26,9 @@ normalize Program {..} = do
   topFuns <- for topFuns \(name, params, ty, expr) -> do
     expr' <- runContT (flat expr) pure
     pure (name, params, ty, expr')
+  moduleName <- asks (.moduleName)
   uniqSupply <- asks (.uniqSupply)
-  expr (alpha ?? AlphaEnv {uniqSupply, subst = mempty}) Program {..}
+  expr (alpha ?? AlphaEnv {uniqSupply, moduleName, subst = mempty}) Program {..}
 
 normalizeExpr ::
   ( MonadReader env m,
@@ -37,7 +38,7 @@ normalizeExpr ::
   ) =>
   Expr (Id Type) ->
   m (Expr (Id Type))
-normalizeExpr e = join $ alpha <$> runContT (flat e) pure <*> (AlphaEnv <$> asks (.uniqSupply) <*> pure mempty)
+normalizeExpr e = join $ alpha <$> runContT (flat e) pure <*> (AlphaEnv <$> asks (.uniqSupply) <*> asks (.moduleName) <*> pure mempty)
 
 -- Traverse the expression tree.
 flat ::
@@ -158,7 +159,7 @@ flatObj (Fun ps e) =
 flatObj o = pure o
 
 inScope ::
-  Monad m =>
+  (Monad m) =>
   -- | continuation
   (a -> m r) ->
   -- | computation must be in the scope

--- a/src/Koriel/Core/Optimize.hs
+++ b/src/Koriel/Core/Optimize.hs
@@ -212,9 +212,10 @@ lookupCallInline call f as = do
       -- v[as/ps]
       -- Test failed in Lint : pure $ foldl' (\e (x, a) -> Assign x (Atom a) e) v $ zip ps as
       -- use Alpha.alpha
+      moduleName <- asks (.moduleName)
       uniqSupply <- asks (.uniqSupply)
       let subst = HashMap.fromList $ zip ps as
-      alpha v (AlphaEnv {uniqSupply, subst})
+      alpha v (AlphaEnv {uniqSupply, moduleName, subst})
     Nothing -> pure $ call f as
 
 -- | Remove a cast if it is redundant.
@@ -234,8 +235,9 @@ foldRedundantCast =
 foldTrivialCall :: (MonadIO f, MonadReader OptimizeEnv f) => Expr (Id Type) -> f (Expr (Id Type))
 foldTrivialCall = transformM \case
   Let [LocalDef f _ (Fun ps body)] (Call (Var f') as) | f == f' -> do
+    moduleName <- asks (.moduleName)
     uniqSupply <- asks (.uniqSupply)
-    alpha body AlphaEnv {uniqSupply, subst = HashMap.fromList $ zip ps as}
+    alpha body AlphaEnv {uniqSupply, moduleName, subst = HashMap.fromList $ zip ps as}
   x -> pure x
 
 -- | Specialize a function which is casted to a specific type.

--- a/src/Koriel/Core/Syntax/Expr.hs
+++ b/src/Koriel/Core/Syntax/Expr.hs
@@ -75,7 +75,7 @@ data Expr a
   deriving stock (Eq, Ord, Show, Functor, Foldable, Generic, Data, Typeable)
   deriving anyclass (Binary, ToJSON, FromJSON)
 
-instance HasType a => HasType (Expr a) where
+instance (HasType a) => HasType (Expr a) where
   typeOf (Atom x) = typeOf x
   typeOf (Call f xs) = case typeOf f of
     ps :-> r | map typeOf xs == ps -> r
@@ -119,7 +119,7 @@ instance HasType a => HasType (Expr a) where
   typeOf (Assign _ _ e) = typeOf e
   typeOf (Error t) = t
 
-instance Pretty a => Pretty (Expr a) where
+instance (Pretty a) => Pretty (Expr a) where
   pPrint (Atom x) = pPrint x
   pPrint (Call f xs) = parens $ "call" <+> pPrint f <+> sep (map pPrint xs)
   pPrint (CallDirect f xs) = parens $ "direct" <+> pPrint f <+> sep (map pPrint xs)

--- a/src/Koriel/Id.hs
+++ b/src/Koriel/Id.hs
@@ -26,7 +26,6 @@ import GHC.Records
 import Koriel.MonadUniq
 import Koriel.Prelude hiding (toList)
 import Koriel.Pretty as P
-import Numeric (showHex)
 
 newtype ModuleName = ModuleName {raw :: Text}
   deriving stock (Eq, Show, Ord, Generic, Data, Typeable)
@@ -61,6 +60,7 @@ data Id a = Id
   { name :: Text,
     meta :: a,
     moduleName :: ModuleName,
+    uniq :: Int, -- Unique number for each Id. If sort == Native or External, uniq is always -1.
     sort :: IdSort
   }
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable, Generic, Data, Typeable)
@@ -68,20 +68,19 @@ data Id a = Id
 
 instance Pretty (Id a) where
   pPrint Id {name, moduleName, sort = External} = "@" <> brackets (pPrint moduleName <+> pPrint name)
-  pPrint Id {name, moduleName, sort = Internal} = "#" <> brackets (pPrint moduleName <+> pPrint name)
-  pPrint Id {name, moduleName, sort = Temporal} = "$" <> brackets (pPrint moduleName <+> pPrint name)
+  pPrint Id {name, moduleName, uniq, sort = Internal} = "#" <> brackets (pPrint moduleName <+> pPrint name <+> pPrint uniq)
+  pPrint Id {name, moduleName, uniq, sort = Temporal} = "$" <> brackets (pPrint moduleName <+> pPrint name <+> pPrint uniq)
   pPrint Id {name, sort = Native} = "%" <> pPrint name
 
 idToText :: Id a -> Text
 idToText Id {name, moduleName, sort = External} = moduleName.raw <> "." <> name
-idToText Id {name, moduleName, sort = Internal} = moduleName.raw <> ".#" <> name
-idToText Id {name, moduleName, sort = Temporal} = moduleName.raw <> ".$" <> name
+idToText Id {name, moduleName, uniq, sort = Internal} = moduleName.raw <> ".#" <> name <> "_" <> convertString (show uniq)
+idToText Id {name, moduleName, uniq, sort = Temporal} = moduleName.raw <> ".$" <> name <> "_" <> convertString (show uniq)
 idToText Id {name, sort = Native} = name
 
 newTemporalId :: (MonadReader env m, MonadIO m, HasUniqSupply env, HasModuleName env) => Text -> a -> m (Id a)
 newTemporalId name meta = do
   uniq <- getUniq
-  name <- pure $ name <> "_" <> convertString (showHex uniq "")
   moduleName <- asks (.moduleName)
   let sort = Temporal
   pure Id {..}
@@ -89,7 +88,6 @@ newTemporalId name meta = do
 newInternalId :: (MonadIO f, MonadReader env f, HasUniqSupply env, HasModuleName env) => Text -> a -> f (Id a)
 newInternalId name meta = do
   uniq <- getUniq
-  name <- pure $ name <> "_" <> convertString (showHex uniq "")
   moduleName <- asks (.moduleName)
   let sort = Internal
   pure Id {..}
@@ -97,12 +95,14 @@ newInternalId name meta = do
 newExternalId :: (MonadReader env f, HasModuleName env) => Text -> a -> f (Id a)
 newExternalId name meta = do
   moduleName <- asks (.moduleName)
+  let uniq = -1
   let sort = External
   pure Id {..}
 
 newNativeId :: (MonadReader env f, HasModuleName env) => Text -> a -> f (Id a)
 newNativeId name meta = do
   moduleName <- asks (.moduleName)
+  let uniq = -1
   let sort = Native
   pure Id {..}
 

--- a/src/Koriel/Id.hs
+++ b/src/Koriel/Id.hs
@@ -67,9 +67,9 @@ data Id a = Id
   deriving anyclass (Hashable, Binary, ToJSON, FromJSON)
 
 instance Pretty (Id a) where
-  pPrint Id {name, moduleName, sort = External} = "@" <> pPrint moduleName <> "." <> pPrint name
-  pPrint Id {name, sort = Internal} = "#" <> pPrint name
-  pPrint Id {name, sort = Temporal} = "$" <> pPrint name
+  pPrint Id {name, moduleName, sort = External} = "@" <> brackets (pPrint moduleName <+> pPrint name)
+  pPrint Id {name, moduleName, sort = Internal} = "#" <> brackets (pPrint moduleName <+> pPrint name)
+  pPrint Id {name, moduleName, sort = Temporal} = "$" <> brackets (pPrint moduleName <+> pPrint name)
   pPrint Id {name, sort = Native} = "%" <> pPrint name
 
 idToText :: Id a -> Text


### PR DESCRIPTION
`Alpha.cloneId` now uses current module name instead of
original id's module name.