### PR TITLE
Add structured errors for Rename and Refine passes

### DIFF
--- a/src/Malgo/Prelude.hs
+++ b/src/Malgo/Prelude.hs
@@ -86,7 +86,6 @@ module Malgo.Prelude
     HasRange (..),
     HasStart (..),
     HasEnd (..),
-    errorOn,
     warningOn,
 
     -- * Uniq
@@ -286,11 +285,6 @@ instance Pretty Range where
       <> pretty (unPos (sourceColumn end))
 
 makeFieldsNoPrefix ''Range
-
-errorOn :: (MonadIO m, Pretty a) => a -> Doc ann -> m b
-errorOn range x = do
-  liftIO $ hPutDoc stderr $ pretty range <> ": " <> x
-  liftIO exitFailure
 
 warningOn :: (MonadIO m, Pretty a) => a -> Doc ann -> m ()
 warningOn range x = do

--- a/src/Malgo/Refine/Error.hs
+++ b/src/Malgo/Refine/Error.hs
@@ -1,0 +1,26 @@
+module Malgo.Refine.Error (RefineError(..)) where
+
+import Malgo.Infer.TypeRep (Type, TypeVar)
+import Malgo.Prelude
+import Malgo.Refine.Space (Space)
+import Prettyprinter (nest, squotes, brackets, vsep, (<+>))
+
+-- | Errors that can occur during the refine pass
+data RefineError
+  = InvalidInstantiation Range TypeVar Type
+  | TypeMismatch Range Type Type
+  | NonExhaustivePatterns Range [Space]
+  deriving stock (Eq, Show)
+
+instance Pretty RefineError where
+  pretty (InvalidInstantiation range v typ) =
+    pretty range <> ": Invalid instantiation:" <+> squotes (pretty v)
+      <+> "can't be instantiated with" <+> pretty typ
+  pretty (TypeMismatch range t1 t2) =
+    pretty range <> ": Type mismatch:" <+> pretty t1 <+> "and" <+> pretty t2
+      <+> "are not the same"
+  pretty (NonExhaustivePatterns range spaces) =
+    vsep
+      [ pretty range <> ": Pattern is not exhaustive:",
+        nest 2 (pretty spaces)
+      ]

--- a/src/Malgo/Rename/Pass.hs
+++ b/src/Malgo/Rename/Pass.hs
@@ -332,7 +332,7 @@ infixDecls ds =
 -- Every OpApp in 'Malgo NewParsed' is treated as left associative.
 -- 'mkOpApp' transforms it to actual associativity.
 mkOpApp ::
-  (IOE :> es, Reader Flag :> es) =>
+  (IOE :> es, Reader Flag :> es, Error RenameError :> es) =>
   Range ->
   -- | Fixity of outer operator
   (Assoc, Int) ->


### PR DESCRIPTION
## Summary
- introduce `RefineError` for the refine pass
- remove `errorOn` helper and use `throwError`
- extend `RenameError` with new constructors
- update passes to throw structured errors

## Testing
- `./test.sh` *(fails: cabal not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468a653d60832fbb6d406e7f4d2b34