### PR TITLE
Insert Closure Pass after renaming

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,9 +32,9 @@ Malgo’s source tree is organized by compiler phases and core abstractions:
 ```
 source file
    ↓
-ParserPass → RenamePass → InferPass → RefinePass
-   ↓           ↓             ↓           ↓
- AST    →  Renamed AST  → Typed AST → Refined AST
+ParserPass → RenamePass → ClosurePass → InferPass → RefinePass
+   ↓           ↓            ↓             ↓           ↓           ↓
+ AST    →  Renamed AST  → Closed AST → Typed AST → Refined AST
    ↓
 ToFunPass → ToCorePass → FlatPass → JoinPass
    ↓           ↓           ↓         ↓
@@ -57,15 +57,19 @@ EvalPass (Interpreter)
 
    - Resolves names, desugars, produces `Module (Malgo Rename)`.
 
-3. **Type Inference** (`InferPass`):
+3. **Closure Conversion** (`ClosurePass`):
+
+   - (Placeholder) converts functions to closures, produces `Module (Malgo Closure)`.
+
+4. **Type Inference** (`InferPass`):
 
    - Infers types/kinds, annotates AST, produces `Module (Malgo Infer)`.
 
-4. **Refinement** (`RefinePass`):
+5. **Refinement** (`RefinePass`):
 
    - Cleans up AST, removes syntactic sugar, produces `Module (Malgo Refine)`.
 
-5. **IR Lowering**:
+6. **IR Lowering**:
 
    - **ToFunPass**: Lowers refined AST to a functional IR (`Sequent.Fun.Program`).
    - **ToCorePass**: Converts Fun IR to a sequent-style Core IR (`Sequent.Core.Program Full`).
@@ -184,6 +188,9 @@ ParserPass
   │
   ▼
 RenamePass
+  │
+  ▼
+ClosurePass
   │
   ▼
 InferPass

--- a/src/Malgo/Closure.hs
+++ b/src/Malgo/Closure.hs
@@ -1,0 +1,20 @@
+module Malgo.Closure (ClosurePass(..)) where
+
+import Data.Void
+import Malgo.Pass
+import Malgo.Syntax (Module (..))
+import Malgo.Syntax.Extension
+
+-- | Dummy closure conversion pass. Currently it performs no transformation.
+data ClosurePass = ClosurePass
+
+instance Pass ClosurePass where
+  type Input ClosurePass = Module (Malgo Rename)
+  type Output ClosurePass = Module (Malgo Closure)
+  type ErrorType ClosurePass = Void
+  type Effects ClosurePass es = ()
+  runPassImpl _ m = pure $ unsafeCoerceModule m
+
+-- | Convert between modules of different phases by reusing the underlying data.
+unsafeCoerceModule :: Module (Malgo a) -> Module (Malgo b)
+unsafeCoerceModule (Module name defs) = Module name defs

--- a/src/Malgo/Driver.hs
+++ b/src/Malgo/Driver.hs
@@ -18,6 +18,7 @@ import Malgo.Pass (CompileError, Pass (..), runCompileError)
 import Malgo.Prelude
 import Malgo.Refine
 import Malgo.Rename
+import Malgo.Closure (ClosurePass (..))
 import Malgo.Sequent.Core (Join)
 import Malgo.Sequent.Core qualified as Sequent
 import Malgo.Sequent.Core.Flat (FlatPass (..))
@@ -70,8 +71,10 @@ compileToCore srcPath parsedAst = do
   rnEnv <- genBuiltinRnEnv
   (renamedAst, rnState) <- withDump flags.debugMode "=== RENAME ===" do
     runPass RenamePass (parsedAst, rnEnv)
+  closedAst <- withDump flags.debugMode "=== CLOSURE ===" do
+    runPass ClosurePass renamedAst
   (typedAst, tcEnv, kindCtx) <- withDump flags.debugMode "=== TYPE CHECK ===" do
-    runPass InferPass (renamedAst, rnEnv)
+    runPass InferPass (closedAst, rnEnv)
   refinedAst <- withDump flags.debugMode "=== REFINE ===" do
     runPass RefinePass (typedAst, tcEnv)
 

--- a/src/Malgo/Syntax.hs
+++ b/src/Malgo/Syntax.hs
@@ -393,6 +393,8 @@ type instance XModule (Malgo 'NewParse) = ParsedDefinitions (Malgo NewParse)
 
 type instance XModule (Malgo 'Rename) = BindGroup (Malgo 'Rename)
 
+type instance XModule (Malgo 'Closure) = BindGroup (Malgo 'Closure)
+
 type instance XModule (Malgo 'Infer) = BindGroup (Malgo 'Infer)
 
 type instance XModule (Malgo 'Refine) = BindGroup (Malgo 'Refine)

--- a/src/Malgo/Syntax/Extension.hs
+++ b/src/Malgo/Syntax/Extension.hs
@@ -78,7 +78,7 @@ import Malgo.SExpr (ToSExpr (..))
 import Malgo.SExpr qualified as S
 
 -- | Phase and type instance
-data MalgoPhase = Parse | Rename | Infer | Refine | NewParse
+data MalgoPhase = Parse | Rename | Closure | Infer | Refine | NewParse
 
 data Malgo (p :: MalgoPhase)
 
@@ -86,6 +86,7 @@ data Malgo (p :: MalgoPhase)
 type family MalgoId (p :: MalgoPhase) where
   MalgoId 'Parse = Text
   MalgoId 'Rename = Id
+  MalgoId 'Closure = Id
   MalgoId 'Infer = Id
   MalgoId 'Refine = Id
   MalgoId 'NewParse = Text
@@ -151,6 +152,8 @@ type family SimpleX (x :: MalgoPhase)
 type instance SimpleX 'Parse = Range
 
 type instance SimpleX 'Rename = SimpleX 'Parse
+
+type instance SimpleX 'Closure = SimpleX 'Rename
 
 -- type instance for Infer is defined in Malgo.Infer.TypeRep
 


### PR DESCRIPTION
## Summary
- define new `Closure` phase in syntax extensions and module instances
- add stub `ClosurePass` implementing the Pass interface
- call `ClosurePass` between renaming and type inference in the driver
- document updated pipeline including the new pass

## Testing
- `./test.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfa3568bc832f8820cc3052dd329e